### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.{rs,toml}]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Standardize whitespace + line endings across editors. 2-space default, 4 for Rust/TOML, preserve trailing spaces in Markdown.